### PR TITLE
Add ad cooldown to VAST plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ Local example:
 
 ## Update Plugin en Peertube after each new build
 ```peertube-cli plugins update --path /absolute/path/to/peertube-plugin-vast-ads```
+
+## Cool off period between ads
+
+From version next, the plugin keeps track of the last time an ad was displayed in the browser. You can configure the delay between ads with the **Ads cool off time (minutes)** setting (default is 5 minutes). When the user opens a new video before this delay has expired, no preroll, midroll or postroll ads will be shown.

--- a/dist/video-watch-client-plugin.js
+++ b/dist/video-watch-client-plugin.js
@@ -2788,8 +2788,9 @@ var require_videojsx_vast = __commonJS({
 var DEFAULT_SKIP_TIME = 8;
 var DEFAULT_SKIP_COUNTDOWN_MESSAGE = "Skip in {seconds}...";
 var DEFAULT_SKIP_MESSAGE = "Skip";
+var DEFAULT_COOLOFF_MINUTES = 5;
 var settings = (s) => {
-  var _a, _b, _c, _d, _e, _f, _g, _h, _i;
+  var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j;
   return {
     preroll: {
       enabled: (_a = s["vast-preroll-enabled"]) != null ? _a : false,
@@ -2809,7 +2810,8 @@ var settings = (s) => {
     skipTime: (_g = s["vast-skip-time"]) != null ? _g : DEFAULT_SKIP_TIME,
     messageSkipCountdown: (_h = s["vast-message-skip-countdown"]) != null ? _h : DEFAULT_SKIP_COUNTDOWN_MESSAGE,
     messageSkip: (_i = s["vast-message-skip"]) != null ? _i : DEFAULT_SKIP_MESSAGE,
-    messageRemainingTime: s["vast-message-remainingTime"]
+    messageRemainingTime: s["vast-message-remainingTime"],
+    coolOffMinutes: (_j = s["vast-cooloff-minutes"]) != null ? _j : DEFAULT_COOLOFF_MINUTES
   };
 };
 var loadContribAds = async (player) => {
@@ -2891,10 +2893,15 @@ async function init(registerHook, peertubeHelpers) {
   }
   const pluginSettings = settings(s);
   const rollsStatus = getRollsStatus(pluginSettings);
+  const getShouldShowAds = () => {
+    const lastAd = parseInt(localStorage.getItem("vastLastAdTimestamp") || "0", 10);
+    const coolOffMs = Number(pluginSettings.coolOffMinutes) * 60 * 1e3;
+    return rollsStatus.hasAtLeastOneRollEnabled && (!coolOffMs || Date.now() - lastAd >= coolOffMs);
+  };
   registerHook({
     target: "filter:internal.video-watch.player.load-options.result",
     handler: (result) => {
-      if (rollsStatus.hasAtLeastOneRollEnabled) {
+      if (getShouldShowAds()) {
         result.autoplay = false;
       }
       return result;
@@ -2903,7 +2910,7 @@ async function init(registerHook, peertubeHelpers) {
   registerHook({
     target: "action:video-watch.player.loaded",
     handler: async ({ videojs: videojs2, player, video }) => {
-      if (!rollsStatus.hasAtLeastOneRollEnabled)
+      if (!getShouldShowAds())
         return;
       window.videojs = videojs2;
       window.player = player;
@@ -2911,6 +2918,7 @@ async function init(registerHook, peertubeHelpers) {
       try {
         const vastSettings = createVastSettings(pluginSettings);
         await buildVastPlayer(vastSettings, player);
+        localStorage.setItem("vastLastAdTimestamp", Date.now().toString());
       } catch (error) {
         console.error("[VAST PLUGIN] Error:", error);
       }

--- a/lib/pluginSettings.js
+++ b/lib/pluginSettings.js
@@ -121,6 +121,14 @@ const pluginSettings = [
     descriptionHTML: 'Message displayed for the countdown to the end of the ad (at bottom left). <br /><em class="fst-italic px-1 text-bg-secondary">{seconds}</em> will be replaced with the number of seconds left to the end of the ad.<br />If empty, the message will not be displayed.',
     private: false,
     default: 'This ad will end in {seconds}',
+  },
+  {
+    name: 'vast-cooloff-minutes',
+    label: 'Ads cool off time (minutes)',
+    type: 'input',
+    descriptionHTML: 'Minimum number of minutes between ads when loading new videos. Use 0 to disable.',
+    private: false,
+    default: '5',
   }
 ];
 

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -1,6 +1,7 @@
 const DEFAULT_SKIP_TIME = 8;
 const DEFAULT_SKIP_COUNTDOWN_MESSAGE = 'Skip in {seconds}...';
 const DEFAULT_SKIP_MESSAGE = 'Skip';
+const DEFAULT_COOLOFF_MINUTES = 5;
 
 export const settings = (s) => ({
   preroll: {
@@ -22,6 +23,7 @@ export const settings = (s) => ({
   messageSkipCountdown: s['vast-message-skip-countdown'] ?? DEFAULT_SKIP_COUNTDOWN_MESSAGE,
   messageSkip: s['vast-message-skip'] ?? DEFAULT_SKIP_MESSAGE,
   messageRemainingTime: s['vast-message-remainingTime'],
+  coolOffMinutes: s['vast-cooloff-minutes'] ?? DEFAULT_COOLOFF_MINUTES,
 });
 
 export const loadContribAds = async (player) => {


### PR DESCRIPTION
## Summary
- allow configuring a cooldown period between ads
- update player code to skip ads if cooldown not expired
- rebuild dist files
- document the new setting in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688d413b85608320bc66030148c4dc00